### PR TITLE
fix: deprecation warning

### DIFF
--- a/duf.rb
+++ b/duf.rb
@@ -6,7 +6,6 @@ class Duf < Formula
   desc "Disk Usage/Free Utility"
   homepage "https://fribbledom.com/"
   version "0.6.2"
-  bottle :unneeded
 
   if OS.mac? && Hardware::CPU.intel?
     url "https://github.com/muesli/duf/releases/download/v0.6.2/duf_0.6.2_Darwin_x86_64.tar.gz"

--- a/gitty.rb
+++ b/gitty.rb
@@ -6,7 +6,6 @@ class Gitty < Formula
   desc "Smart little CLI helper for git projects"
   homepage "https://fribbledom.com/"
   version "0.3.0"
-  bottle :unneeded
 
   on_macos do
     if Hardware::CPU.intel?

--- a/gulp.rb
+++ b/gulp.rb
@@ -6,7 +6,6 @@ class Gulp < Formula
   desc "Smart little CLI helper for git projects"
   homepage "https://fribbledom.com/"
   version "0.1.0"
-  bottle :unneeded
 
   on_macos do
     if Hardware::CPU.intel?

--- a/markscribe.rb
+++ b/markscribe.rb
@@ -6,7 +6,6 @@ class Markscribe < Formula
   desc "Your personal markdown scribe with template-engine and Git(Hub) & RSS powers"
   homepage "https://fribbledom.com/"
   version "0.6.0"
-  bottle :unneeded
 
   on_macos do
     if Hardware::CPU.intel?

--- a/mastotool.rb
+++ b/mastotool.rb
@@ -3,7 +3,6 @@ class Mastotool < Formula
   desc "Mastodon CLI tool & statistics generator"
   homepage "https://fribbledom.com/"
   version "0.2.4"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/muesli/mastotool/releases/download/v0.2.4/mastotool_0.2.4_Darwin_x86_64.tar.gz"

--- a/obs-cli.rb
+++ b/obs-cli.rb
@@ -6,7 +6,6 @@ class ObsCli < Formula
   desc "OBS-cli is a command-line remote control for OBS"
   homepage "https://fribbledom.com/"
   version "0.2.0"
-  bottle :unneeded
 
   on_macos do
     if Hardware::CPU.intel?

--- a/prism.rb
+++ b/prism.rb
@@ -3,7 +3,6 @@ class Prism < Formula
   desc "Disk Usage/Free Utility"
   homepage "https://fribbledom.com/"
   version "0.1.1"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/muesli/prism/releases/download/v0.1.1/prism_0.1.1_Darwin_x86_64.tar.gz"


### PR DESCRIPTION
fixes this:

```
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the muesli/tap tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/muesli/homebrew-tap/gitty.rb:9
```

latest goreleaser versions should generate the taps without it already :) 


closes #4 

cc/ @muesli 
